### PR TITLE
Added docker compose for mongo and fake test email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ uploads
 node_modules
 
 # Ignore files related to API keys
-*.env
+
 config/config.env

--- a/app.js
+++ b/app.js
@@ -41,7 +41,7 @@ const port = 8081;
 
 //LOAD CONFIG.ENV VARS
 dotenv.config({
-	path: './config/config.env'
+	path: './config/dev-config.env'
 });
 
 //DB SET UP & APP LISTEN (server starts after db connection)
@@ -61,6 +61,14 @@ mongoose.connect(process.env.MONGO_URI, options, (err, database) => {
 	}
 });
 
+const sendMail = require('./controllers/email');
+sendMail('bla@bla.de', 'bla', 'bla', 'blabla', (err, data) => {
+	if (err) {
+		console.log(err);
+	} else {
+		console.log("email successfully sent");
+	}
+})
 //IMPORT MODELS
 const User = require('./models/User');
 

--- a/app.js
+++ b/app.js
@@ -61,14 +61,6 @@ mongoose.connect(process.env.MONGO_URI, options, (err, database) => {
 	}
 });
 
-const sendMail = require('./controllers/email');
-sendMail('bla@bla.de', 'bla', 'bla', 'blabla', (err, data) => {
-	if (err) {
-		console.log(err);
-	} else {
-		console.log("email successfully sent");
-	}
-})
 //IMPORT MODELS
 const User = require('./models/User');
 

--- a/app.js
+++ b/app.js
@@ -41,7 +41,7 @@ const port = 8081;
 
 //LOAD CONFIG.ENV VARS
 dotenv.config({
-	path: './config/dev-config.env'
+	path: './config/config.env'
 });
 
 //DB SET UP & APP LISTEN (server starts after db connection)

--- a/app.js
+++ b/app.js
@@ -61,6 +61,14 @@ mongoose.connect(process.env.MONGO_URI, options, (err, database) => {
 	}
 });
 
+const sendMail = require('./controllers/email');
+sendMail('bla@bla.de', 'bla', 'bla', 'blabla', (err, data) => {
+	if (err) {
+		console.log(err);
+	} else {
+		console.log("email successfully sent");
+	}
+})
 //IMPORT MODELS
 const User = require('./models/User');
 

--- a/config/example-config.env
+++ b/config/example-config.env
@@ -1,0 +1,9 @@
+
+MONGO_URI=mongodb://localhost/donategifts?w=majority
+NODE_ENV=development
+SESS_NAME=sid
+SESS_SECRET=d5ce4cdd-8a3c-41d1-a076-6c8ffc281f2a
+SESS_LIFE=3600000
+MAILGUN_API_KEY=onlyneededforproduction
+MAILGUN_DOMAIN=onlyneededforproduction
+

--- a/controllers/email.js
+++ b/controllers/email.js
@@ -14,41 +14,77 @@
 //NPM DEPENDENCIES
 const nodemailer = require('nodemailer');
 const mailGun = require('nodemailer-mailgun-transport');
-const dotenv = require('dotenv');
-
-//LOAD ENV VARS - we save all api keys in env for security
-dotenv.config({ path: './config/config.env' });
-
-//MAILGUN AUTHENTICATION
-const auth = {
-	auth: {
-		api_key: process.env.MAILGUN_API_KEY,
-		domain: process.env.MAILGUN_DOMAIN
-	}
-}
-
-const transporter = nodemailer.createTransport(mailGun(auth));
 
 //cb is callback, cb(err, null) means if err, get err, else null
 //IF WE WANT TO CHANGE THE RECIPIENT ADDRESS LATER, MUST AUTHORIZE IN MAILGUN SYSTEM FIRST
 const sendMail = (email, name, subject, message, cb) => {
-    
-	const mailOptions = {
-		from: email,
-		to: 'stacy.sealky.lee@gmail.com',
-		subject: `${subject} | sent by: ${name}`,
-		text: message
-	};
 	
-	transporter.sendMail(mailOptions, (err, data) => {
-		if (err) {
-			cb(err, null);
-			console.log(err);
-		} else {
-			cb(null, data);
-			console.log("sendMail function successfully called");			
-		}
-	});
+	getTransport()
+	.then(transport => {
+		const mailOptions = {
+			from: email,
+			to: 'stacy.sealky.lee@gmail.com',
+			subject: `${subject} | sent by: ${name}`,
+			text: message
+		};
+		
+		transporter.sendMail(mailOptions, (err, data) => {
+			if (err) {
+				cb(err, null);
+				console.log(err);
+			} else {
+				console.log("sendMail function successfully called");	
+				if (process.env.NODE_ENV === 'development') {
+					console.log('Preview URL: %s', nodemailer.getTestMessageUrl(data));	
+				} 
+				cb(null, data);
+			}
+		});
+	})	
 };
+
+const getTransport = () => {
+
+	return new Promise((resolve, reject)=> {
+
+		if (process.env.NODE_ENV === 'development') {
+
+			nodemailer.createTestAccount((err, account) => {
+				if (err) {
+					reject('Failed to create a testing account. ' + err.message)
+					console.error('Failed to create a testing account. ' + err.message);
+				}
+			
+				// Create a SMTP transporter object
+				transporter = nodemailer.createTransport({
+					host: account.smtp.host,
+					port: account.smtp.port,
+					secure: account.smtp.secure,
+					auth: {
+						user: account.user,
+						pass: account.pass
+					}
+				});
+				resolve(transporter);
+		
+			});
+
+			//LIVE data
+		} else {
+			const auth = {
+				auth: {
+					api_key: process.env.MAILGUN_API_KEY,
+					domain: process.env.MAILGUN_DOMAIN
+				}
+			}
+			
+			const transporter = nodemailer.createTransport(mailGun(auth));
+			resolve(transporter);
+
+		}
+	})
+
+}
+
 
 module.exports = sendMail;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.1'
+
+services:
+  mongo:
+    image: mongo
+    restart: unless-stopped
+    ports:
+      - 27017:27017
+      
+    volumes: 
+      - donategifts_mongo:/data/db
+
+volumes:
+  donategifts_mongo:

--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,10 @@
 
 ## Usage
 
+Install Mongo or use Docker to spin up a Docker container
+start container with:
+`docker-compose up`
 App will not run without config.env !
-
-db url and other api keys, SMTP info are hidden in config.env file -- which is not pushed to github. Ask Stacy or another contributor for the config file.
 
 public dir has all the static components. assets dir contains font and imgs. 
 


### PR DESCRIPTION
Mongo can now be started with docker, this way no one has to install mongo on their machine.

I also added fake email transports so if emails have to be tested we won't use real ones until necessary.

Removed a few dotenv requires since it only has to be called once in the app.js and then works everywhere