### PR TITLE
Toast for Wishcard Creation

### DIFF
--- a/public/clientJS/chooseItem.js
+++ b/public/clientJS/chooseItem.js
@@ -26,7 +26,7 @@ $(document).ready(function () {
     });
   });
 
-  $('#wishCardForm').on('submit', function (e) {
+  $('#wishCardFormGuided').on('submit', function (e) {
     e.preventDefault();
 
     var form = $(this);
@@ -40,12 +40,16 @@ $(document).ready(function () {
       contentType: false,
       cache: false,
       timeout: 600000,
-      success: function () {
-        showToast('WishCard Created!');
-      },
-      error: function (response, textStatus, errorThrown) {
-        let txtToJson = JSON.parse(response.responseText);
-        showToast(txtToJson.error);
+      statusCode: {
+        200: function (route) {
+          $('#wishCardFormGuided')[0].reset();
+          showToast('WishCard Created!');
+          setTimeout(() => location.assign(route), 2000);
+        },
+        400: function (response) {
+          let txtToJson = JSON.parse(response.responseText);
+          showToast(txtToJson.error);
+        },
       },
     });
   });

--- a/public/clientJS/profile.js
+++ b/public/clientJS/profile.js
@@ -1,69 +1,91 @@
 $(document).ready(() => {
-    var fileTag = document.getElementById("filetag"),
-        preview = document.getElementById("preview");
-    fileTag.addEventListener("change", function () {
-        changeImage(this);
-    });
+  var fileTag = document.getElementById('filetag'),
+    preview = document.getElementById('preview');
+  fileTag.addEventListener('change', function () {
+    changeImage(this);
+  });
 
-    function changeImage(input) {
-        var reader;
+  function changeImage(input) {
+    var reader;
 
-        if (input.files && input.files[0]) {
-            reader = new FileReader();
+    if (input.files && input.files[0]) {
+      reader = new FileReader();
 
-            reader.onload = function (e) {
-                preview.setAttribute('src', e.target.result);
-            }
+      reader.onload = function (e) {
+        preview.setAttribute('src', e.target.result);
+      };
 
-            reader.readAsDataURL(input.files[0]);
-        }
+      reader.readAsDataURL(input.files[0]);
     }
+  }
 
+  $('#wishCardForm').on('submit', function (e) {
+    e.preventDefault();
+
+    var form = $(this);
+    var formdata = new FormData(form[0]);
+    $.ajax({
+      type: 'POST',
+      enctype: 'multipart/form-data',
+      url: '/wishcards/',
+      data: formdata,
+      processData: false,
+      contentType: false,
+      cache: false,
+      timeout: 600000,
+      statusCode: {
+        200: function (route) {
+          $('#wishCardForm')[0].reset();
+          showToast('WishCard Created!');
+          setTimeout(() => location.assign(route), 2000);
+        },
+        400: function (response) {
+          let txtToJson = JSON.parse(response.responseText);
+          showToast(txtToJson.error);
+        },
+      },
+    });
+  });
 });
 
+// About me edit. Click handler
+window.onload = function () {
+  let buttonSaveProfile = document.getElementById('save-about-me-button');
 
-// About me edit. Click handler 
-window.onload = function() {
-    let buttonSaveProfile = document.getElementById("save-about-me-button");
+  // button listener
+  function handleSaveAboutMeButtonClick() {
+    let aboutMeElemet = document.getElementById('about-me-text');
+    let aboutMeText = aboutMeElemet.value;
+    updateAboutMe(aboutMeText);
+  }
 
-    // button listener
-    function handleSaveAboutMeButtonClick() {
-        let aboutMeElemet = document.getElementById("about-me-text");
-        let aboutMeText = aboutMeElemet.value;
-        updateAboutMe(aboutMeText);
-        
-    }
+  // submit update request to the server
+  function updateAboutMe(info) {
+    let aboutMe = { aboutMe: info };
+    let url = '/users/profile';
+    fetch(url, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(aboutMe),
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        // if there was an error on the backend do not append about me
+        if (data.error) {
+          showToast('Could not update about me info.');
+          console.log(data);
+          return;
+        }
+        let aboutMeElement = document.getElementById('about-me');
+        aboutMeElement.innerText = data.data;
+      })
+      .catch((error) => {
+        console.error('Error:', error);
+        showToast('Could not update about me info.');
+      });
+  }
 
-    // submit update request to the server
-    function updateAboutMe(info) {
-        let aboutMe = {aboutMe: info};
-        let url = "/users/profile";
-        fetch(url, {
-            method: "PUT",
-            headers: {
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify(aboutMe),
-            })
-            .then(response => response.json())
-            .then(data => {
-                // if there was an error on the backend do not append about me
-                if (data.error){
-                    showToast("Could not update about me info.");
-                    console.log(data);
-                    return;
-                }
-                let aboutMeElement = document.getElementById("about-me");
-                aboutMeElement.innerText = data.data;
-            })
-            .catch((error) => {
-                console.error("Error:", error);
-                showToast("Could not update about me info.");
-            });
-    }
-
-    buttonSaveProfile.addEventListener("click", handleSaveAboutMeButtonClick);
-}
-
-
-
+  buttonSaveProfile.addEventListener('click', handleSaveAboutMeButtonClick);
+};

--- a/routes/wishCards.js
+++ b/routes/wishCards.js
@@ -69,10 +69,12 @@ const User = require('../models/User');
 // @tested 	Yes
 router.post('/', upload.single('wishCardImage'), (req, res) => {
   if (req.file === undefined) {
-    res.send(
-      'Error: File must be in jpeg, jpg, gif, or png format. The file \
-        must also be less than 5 megabytes.'
-    );
+    res.status(400).send({
+      success: false,
+      error:
+        'Error: File must be in jpeg, jpg, gif, or png format. The file \
+        must also be less than 5 megabytes.',
+    });
   } else {
     try {
       let newCard = new WishCard({
@@ -95,7 +97,7 @@ router.post('/', upload.single('wishCardImage'), (req, res) => {
         if (err) {
           res.status(400).json({ success: false, error: err });
         } else {
-          res.status(200).json({ success: true });
+          res.status(200).send('/wishcards/');
         }
       });
     } catch (error) {
@@ -110,10 +112,12 @@ router.post('/', upload.single('wishCardImage'), (req, res) => {
 // @tested 	Yes
 router.post('/guided/', upload.single('wishCardImage'), (req, res) => {
   if (req.file === undefined) {
-    res.send(
-      'Error: File must be in jpeg, jpg, gif, or png format. The file \
-        must also be less than 5 megabytes.'
-    );
+    res.status(400).send({
+      success: false,
+      error:
+        'Error: File must be in jpeg, jpg, gif, or png format. The file \
+        must also be less than 5 megabytes.',
+    });
   } else {
     try {
       let { itemChoice } = req.body;
@@ -137,10 +141,9 @@ router.post('/guided/', upload.single('wishCardImage'), (req, res) => {
       });
       newCard.save((err, data) => {
         if (err) {
-          console.log(err);
           res.status(400).json({ success: false, error: err });
         } else {
-          res.status(200).json({ success: true, error: 'No error' });
+          res.status(200).send('/wishcards/');
         }
       });
     } catch (error) {
@@ -161,12 +164,10 @@ router.get('/', async (req, res) => {
       wishcards: results,
     });
   } catch (error) {
-    res.status(400).send(
-      JSON.stringify({
-        success: false,
-        error: error,
-      })
-    );
+    res.status(400).send({
+      success: false,
+      error: error,
+    });
   }
 });
 
@@ -187,12 +188,10 @@ router.post('/search', async (req, res) => {
       wishcards: results,
     });
   } catch (error) {
-    res.status(400).send(
-      JSON.stringify({
-        success: false,
-        error: error,
-      })
-    );
+    res.status(400).send({
+      success: false,
+      error: error,
+    });
   }
 });
 
@@ -259,12 +258,10 @@ router.get('/:id', async (req, res) => {
         defaultMessages,
       });
     } catch (error) {
-      res.status(400).send(
-        JSON.stringify({
-          success: false,
-          error: error,
-        })
-      );
+      res.status(400).send({
+        success: false,
+        error: error,
+      });
     }
   }
 });
@@ -286,7 +283,7 @@ router.get('/get/random', async (req, res) => {
       if (error) {
         res.status(400).json({ success: false, error });
       } else {
-        res.send(html);
+        res.status(200).send(html);
       }
     });
   } catch (error) {
@@ -314,12 +311,10 @@ router.put('/update/:id', async (req, res) => {
         */
     result.save();
   } catch (error) {
-    res.status(400).send(
-      JSON.stringify({
-        success: false,
-        error: error,
-      })
-    );
+    res.status(400).send({
+      success: false,
+      error: error,
+    });
   }
 });
 
@@ -340,27 +335,22 @@ router.post('/message', async (req, res) => {
     );
 
     if (updatedWishCard) {
-      res.status(200).send(
-        JSON.stringify({
-          success: true,
-          error: null,
-          data: newMessage,
-        })
-      );
+      res.status(200).send({
+        success: true,
+        error: null,
+        data: newMessage,
+      });
     } else {
-      res.status(400).send(
-        JSON.stringify({
-          success: false,
-        })
-      );
+      res.status(400).send({
+        success: false,
+        error: 'Could not Update Card',
+      });
     }
   } catch (error) {
-    res.status(400).send(
-      JSON.stringify({
-        success: false,
-        error: error,
-      })
-    );
+    res.status(400).send({
+      success: false,
+      error: error,
+    });
   }
 });
 

--- a/views/chooseItem.ejs
+++ b/views/chooseItem.ejs
@@ -24,7 +24,7 @@
     <div class="container-fluid">
         <div class="create-wish-card">
             <!-- wishCardForm starts here-->
-            <form class="container-fluid" id="wishCardForm" action="/wishcards/guided/" method="POST"
+            <form class="container-fluid" id="wishCardFormGuided" action="/wishcards/guided/" method="POST"
                 enctype="multipart/form-data">
                 <h4 class="crayon-font wish-card-form-title">
                     For a faster wish card creation <br />


### PR DESCRIPTION
- Added toast notification + redirect to /wishcards/
	- The redirect is set with a timeout (2000ms). Test it out and see if it feels weird from a UX perspective. We can reduce the time if not.
- Reset the wishcard creation forms
	- If submission is successful, form is reset
- Removed JSON.stringify with res.send in wishcard routes (redundant when sending objects)
- Added status codes to some of the responses in wishcard routes
- Changed ajax responses for wishcard form handling from (success/failure) to statusCode based (200 for success, 400 if not).
- Side not, as a benefit of last two, toast also shows messages when file format is not accurate (though, it presents the same message if file is not present). We should probably handle the cases separately.
