### PR TITLE
Don-17 login without verification

### DIFF
--- a/app.js
+++ b/app.js
@@ -96,10 +96,12 @@ app.use(async (req, res, next) => {
   if (user) {
     const result = await User.findById(user._id);
     res.locals.user = result;
+    req.session.user = result;
   }
   if (agencyId) {
     const result = await Agency.findById(agencyId);
     res.locals.agency = result;
+    req.session.agency = result;
   }
   next();
 });

--- a/app.js
+++ b/app.js
@@ -40,12 +40,12 @@ const hostname = '127.0.0.1';
 const port = 8081;
 
 //LOAD CONFIG.ENV vars
-let configPath = './config/config.env'
+let configPath = './config/config.env';
 if (process.env.NODE_ENV === 'test') {
-    configPath = './config/test.config.env'
+  configPath = './config/test.config.env';
 }
 dotenv.config({
-    path: configPath,
+  path: configPath,
 });
 
 //DB SET UP & APP LISTEN (server starts after db connection)
@@ -89,19 +89,20 @@ app.use(
   })
 );
 
-
-// MIDDLEWARE for extracting userId from a session
+// MIDDLEWARE for extracting user and agency from a session
 app.use(async (req, res, next) => {
-  const { user, agencyId } = req.session;
+  const { user } = req.session;
   if (user) {
     const result = await User.findById(user._id);
     res.locals.user = result;
     req.session.user = result;
-  }
-  if (agencyId) {
-    const result = await Agency.findById(agencyId);
-    res.locals.agency = result;
-    req.session.agency = result;
+    if (user.userRole === 'partner') {
+      const agency = await Agency.findOne({ accountManager: user._id });
+      if (agency !== null) {
+        res.locals.agency = agency;
+        req.session.agency = agency;
+      }
+    }
   }
   next();
 });

--- a/public/clientJS/agency.js
+++ b/public/clientJS/agency.js
@@ -1,33 +1,31 @@
 $(document).ready(function () {
-  $(".signup-agency").submit(function (e) {
+  $('.signup-agency').submit(function (e) {
     e.preventDefault();
-    $("#submit-btn").prop("disabled",true);
+    $('#submit-btn').prop('disabled', true);
 
-    let agencyName = $("#agencyName").val();
-    let agencyWebsite = $("#agencyWebsite").val();
-    let agencyPhone = $("#agencyPhone").val();
-    let agencyBio = $("#agencyBio").val();
+    let agencyName = $('#agencyName').val();
+    let agencyWebsite = $('#agencyWebsite').val();
+    let agencyPhone = $('#agencyPhone').val();
+    let agencyBio = $('#agencyBio').val();
 
     $.ajax({
-      type: "POST",
-      url: "/users/agency",
+      type: 'POST',
+      url: '/users/agency',
       data: {
         agencyName,
         agencyWebsite,
         agencyPhone,
         agencyBio,
       },
-      statusCode: {
-        409: function (responseObject, textStatus, jqXHR) {
-          showToast(responseObject.responseText);
-          $("#submit-btn").prop("disabled",false);
-
-        },
-        200: function (responseObject, textStatus, errorThrown) {
-          location.replace(responseObject);
-          $("#submit-btn").prop("disabled",false);
-
-        },
+      success: function (response, textStatus, jqXHR) {
+        $('#submit-btn').prop('disabled', false);
+        location.assign(response.url);
+      },
+      error: function (response, textStatus, errorThrown) {
+        let txtToJson = JSON.parse(response.responseText);
+        let errorMsg = txtToJson.error;
+        showToast(errorMsg.msg);
+        $('#submit-btn').prop('disabled', false);
       },
     });
   });

--- a/public/clientJS/signup.js
+++ b/public/clientJS/signup.js
@@ -24,18 +24,12 @@ $(document).ready(function () {
         userRole: userRole
       },
       success: function(response, textStatus, xhr) {
-        $("#submit-btn").prop("disabled",false);
-      
-        showToast("Please check your mails for a verification email");
-        console.log(response.email)
-        setTimeout(function(){ window.location = "/users/login" }, response.dev?15000:3000);
-
+        location.assign(response.url);
       },
       error: function(response, textStatus, errorThrown) {
         let txtToJson =  JSON.parse(response.responseText);
         showToast(txtToJson.error);
         $("#submit-btn").prop("disabled",false);
-
       }
     });
 })

--- a/routes/users.js
+++ b/routes/users.js
@@ -281,14 +281,6 @@ router.post(
     });
     if (user) {
       if (await bcrypt.compare(password, user.password)) {
-        if (!user.emailVerified) {
-          return res.status(403).render('login', {
-            user: res.locals.user,
-            successNotification: null,
-            errorNotification: { msg: 'Please verify your Email' },
-          });
-        }
-
         req.session.user = user;
         res.locals.user = user;
         return res.redirect('/users/profile');
@@ -306,8 +298,6 @@ router.post(
         errorNotification: { msg: 'Username and/or password incorrect' },
       });
     }
-
-    res.redirect('/users/login');
   }
 );
 
@@ -356,7 +346,7 @@ router.get('/verify/:hash', async (req, res) => {
         return res.status(200).render('login', {
           user: res.locals.user,
           successNotification: {
-            msg: 'Your email is already verified, you can login now!',
+            msg: 'Your email is already verified.',
           },
           errorNotification: null,
         });
@@ -367,7 +357,7 @@ router.get('/verify/:hash', async (req, res) => {
       return res.status(200).render('login', {
         user: res.locals.user,
         successNotification: {
-          msg: 'Verification successful, you can login now!',
+          msg: 'Email Verification successful',
         },
         errorNotification: null,
       });
@@ -375,14 +365,14 @@ router.get('/verify/:hash', async (req, res) => {
       return res.status(400).render('login', {
         user: res.locals.user,
         successNotification: null,
-        errorNotification: { msg: 'Verification failed' },
+        errorNotification: { msg: 'Email Verification failed' },
       });
     }
   } catch (error) {
     return res.status(500).render('login', {
       user: res.locals.user,
       successNotification: null,
-      errorNotification: { msg: 'Verification failed' },
+      errorNotification: { msg: 'Email Verification failed' },
     });
   }
 });

--- a/routes/users.js
+++ b/routes/users.js
@@ -145,11 +145,10 @@ router.put(
         return sendError(res, 404, 'User could not be found');
       }
 
-      // update user and add aboutMe
-      User.updateOne(
+      // update user and add aboutMe;
+      await User.findByIdAndUpdate(
         { _id: candidate._id },
-        { aboutMe: aboutMe },
-        { multi: true }
+        { $set: { aboutMe: aboutMe } }
       );
 
       res.status(200).send(

--- a/routes/users.js
+++ b/routes/users.js
@@ -105,15 +105,14 @@ router.get('/login', redirectProfile, (req, res) => {
 router.get('/profile', redirectLogin, async (req, res) => {
   try {
     let user = req.session.user;
-    let params = { user };
     if (user.userRole === 'partner') {
       let agency = await Agency.findOne({ accountManager: user._id });
+      // If user hadn't filled out agency info, redirect them to form
       if (!agency) {
-        return res.render('agency');
+        return res.status(200).render('agency');
       }
-      params = { ...params, agency };
     }
-    res.render('profile', params);
+    res.status(200).render('profile');
   } catch (err) {
     console.log(err);
     return sendError(res, 400, err);

--- a/routes/users.js
+++ b/routes/users.js
@@ -199,8 +199,11 @@ router.post(
     try {
       await newAgency.save();
 
-      req.session.agencyId = mongoose.Types.ObjectId(newAgency._id);
-      res.send('/users/profile');
+      return res.status(200).send({
+        success: true,
+        user: req.session.user,
+        url: '/users/profile',
+      });
     } catch (err) {
       console.log(err);
       return sendError(res, 400, err);

--- a/test/users.test.js
+++ b/test/users.test.js
@@ -361,6 +361,7 @@ describe('Users', () => {
         .post('/users/signup')
         .send(signupRequest)
         .end((err, res) => {
+          res.should.have.status(200);
           res.body.success.should.equal(true);
           res.body.should.have.property('user');
           res.body.user.should.have.property('fName');

--- a/test/users.test.js
+++ b/test/users.test.js
@@ -101,16 +101,16 @@ describe('Users', () => {
           res.body.user.should.have.property('userRole');
           res.body.user.should.have.property('_id');
           res.body.user.emailVerified.should.equal(false);
+
           User.findOne({ email: signupRequest.email }).then((user) => {
             user.id.should.equal(res.body.user._id);
+            user.email.should.equal(signupRequest.email);
 
             agent
               .get('/users/verify/' + user.verificationHash)
               .end((err, res) => {
                 res.should.have.status(200);
-                res.text.should.contain(
-                  'Verification successful, you can login now!'
-                );
+                res.text.should.contain('Verification successful');
 
                 User.findOne({ email: signupRequest.email }).then((user) => {
                   user.emailVerified.should.equal(true);
@@ -143,7 +143,7 @@ describe('Users', () => {
       });
     });
 
-    it('should get profile when logged in', (done) => {
+    it('should get profile when logged in and display unverified email message', (done) => {
       agent
         .post('/users/signup')
         .send(signupRequest)
@@ -160,23 +160,43 @@ describe('Users', () => {
           res.body.user.should.have.property('userRole');
           res.body.user.should.have.property('_id');
           res.body.user.emailVerified.should.equal(false);
-
+          res.body.should.have.property('url');
           User.findOne({ email: signupRequest.email }).then((user) => {
-            user.emailVerified = true;
-            user.save();
+            user.id.should.equal(res.body.user._id);
 
-            let loginRequest = {
-              email: 'test@email.de',
-              password: 'testPassword',
-            };
+            agent.get('/users/profile').end((err, res) => {
+              res.text.should.contain('Welcome ' + user.fName);
+              res.text.should.contain('Your email is unverified');
+              done();
+            });
+          });
+        });
+    });
+
+    it('should not display unverified email message once email is verified', (done) => {
+      agent
+        .post('/users/signup')
+        .send(signupRequest)
+        .end((err, res) => {
+          res.should.have.status(200);
+          User.findOne({ email: signupRequest.email }).then((user) => {
+            user.emailVerified.should.equal(false);
             agent
-              .post('/users/login')
-              .redirects(1)
-              .send(loginRequest)
+              .get('/users/verify/' + user.verificationHash)
               .end((err, res) => {
                 res.should.have.status(200);
-                res.text.should.contain('Welcome ' + user.fName);
-                done();
+                res.text.should.contain('Verification successful');
+
+                User.findOne({ email: signupRequest.email }).then((user) => {
+                  user.emailVerified.should.equal(true);
+
+                  agent.get('/users/profile').end((err, res) => {
+                    res.should.have.status(200);
+                    res.text.should.contain('Welcome ' + user.fName);
+                    res.text.should.not.contain('Your email is unverified');
+                    done();
+                  });
+                });
               });
           });
         });
@@ -268,20 +288,9 @@ describe('Users', () => {
         .send(signupRequest)
         .end((err, res) => {
           res.should.have.status(200);
-          res.body.success.should.equal(true);
-          res.body.should.have.property('user');
-          res.body.user.should.have.property('fName');
-          res.body.user.should.have.property('lName');
-          res.body.user.should.have.property('email');
-          res.body.user.should.have.property('emailVerified');
-          res.body.user.should.have.property('verificationHash');
-          res.body.user.should.have.property('password');
-          res.body.user.should.have.property('userRole');
-          res.body.user.should.have.property('_id');
-          res.body.user.emailVerified.should.equal(false);
 
           User.findOne({ email: signupRequest.email }).then((user) => {
-            user.id.should.equal(res.body.user._id);
+            user.email.should.equal(signupRequest.email);
             done();
           });
         });
@@ -335,39 +344,6 @@ describe('Users', () => {
           done();
         });
     });
-
-    it('it should not login without verified email', (done) => {
-      agent
-        .post('/users/signup')
-        .send(signupRequest)
-        .end((err, res) => {
-          res.should.have.status(200);
-          res.body.success.should.equal(true);
-          res.body.should.have.property('user');
-          res.body.user.should.have.property('fName');
-          res.body.user.should.have.property('lName');
-          res.body.user.should.have.property('email');
-          res.body.user.should.have.property('emailVerified');
-          res.body.user.should.have.property('verificationHash');
-          res.body.user.should.have.property('password');
-          res.body.user.should.have.property('userRole');
-          res.body.user.should.have.property('_id');
-          res.body.user.emailVerified.should.equal(false);
-
-          let loginRequest = {
-            email: 'test@email.de',
-            password: 'testPassword',
-          };
-          agent
-            .post('/users/login')
-            .send(loginRequest)
-            .end((err, res) => {
-              res.should.have.status(403);
-              res.text.should.contain('Please verify your Email');
-              done();
-            });
-        });
-    });
   });
 
   describe('/POST users/agency', () => {
@@ -379,13 +355,12 @@ describe('Users', () => {
       });
     });
 
-    it('it should show agency registration page when logged in and partner', (done) => {
+    it('it should show agency registration page after initial registration for partners', (done) => {
       signupRequest.userRole = 'partner';
       agent
         .post('/users/signup')
         .send(signupRequest)
         .end((err, res) => {
-          res.should.have.status(200);
           res.body.success.should.equal(true);
           res.body.should.have.property('user');
           res.body.user.should.have.property('fName');
@@ -397,45 +372,22 @@ describe('Users', () => {
           res.body.user.should.have.property('userRole');
           res.body.user.should.have.property('_id');
           res.body.user.emailVerified.should.equal(false);
+          res.body.should.have.property('url');
 
-          User.findOne({ email: signupRequest.email }).then((user) => {
-            user.emailVerified = true;
-            user.save();
-
-            let loginRequest = {
-              email: 'test@email.de',
-              password: 'testPassword',
-            };
-            agent
-              .post('/users/login')
-              .redirects(1)
-              .send(loginRequest)
-              .end((err, res) => {
-                res.should.have.status(200);
-                res.text.should.contain('agency registration page');
-
-                agent
-                  .get('/users/agency')
-                  .redirects(1)
-                  .send(loginRequest)
-                  .end((err, res) => {
-                    res.should.have.status(200);
-                    res.text.should.contain('agency registration page');
-                    done();
-                  });
-              });
+          agent.get('/users/agency').end((err, res) => {
+            res.should.have.status(200);
+            res.text.should.contain('agency registration page');
+            done();
           });
         });
     });
 
-    it('it should save agency when logged in and partner', (done) => {
+    it('it should always redirect to agency registration if user has not completed it and navigates away', (done) => {
       signupRequest.userRole = 'partner';
-
       agent
         .post('/users/signup')
         .send(signupRequest)
         .end((err, res) => {
-          res.should.have.status(200);
           res.body.success.should.equal(true);
           res.body.should.have.property('user');
           res.body.user.should.have.property('fName');
@@ -447,37 +399,65 @@ describe('Users', () => {
           res.body.user.should.have.property('userRole');
           res.body.user.should.have.property('_id');
           res.body.user.emailVerified.should.equal(false);
+          res.body.should.have.property('url');
 
-          User.findOne({ email: signupRequest.email }).then((user) => {
-            user.emailVerified = true;
-            user.save();
+          agent
+            .get('/users/profile')
+            .redirects(1)
+            .end((err, res) => {
+              res.should.have.status(200);
+              res.text.should.contain('agency registration page');
+              done();
+            });
+        });
+    });
 
-            let loginRequest = {
-              email: 'test@email.de',
-              password: 'testPassword',
-            };
-            agent
-              .post('/users/login')
-              .redirects(1)
-              .send(loginRequest)
-              .end((err, res) => {
-                res.should.have.status(200);
-                res.text.should.contain(' agency registration page');
+    it('it should save agency information', (done) => {
+      signupRequest.userRole = 'partner';
+      agent
+        .post('/users/signup')
+        .send(signupRequest)
+        .end((err, res) => {
+          res.body.success.should.equal(true);
+          res.body.should.have.property('user');
+          res.body.user.should.have.property('fName');
+          res.body.user.should.have.property('lName');
+          res.body.user.should.have.property('email');
+          res.body.user.should.have.property('emailVerified');
+          res.body.user.should.have.property('verificationHash');
+          res.body.user.should.have.property('password');
+          res.body.user.should.have.property('userRole');
+          res.body.user.should.have.property('_id');
+          res.body.user.emailVerified.should.equal(false);
+          res.body.should.have.property('url');
 
-                let agencyRequest = {
-                  agencyName: 'testAgencyName',
-                  agencyWebsite: 'http://testAgencyWebsite',
-                  agencyPhone: '12334556',
-                  agencyBio: 'testAgencyBio',
-                };
+          agent.get('/users/agency').end((err, res) => {
+            res.should.have.status(200);
+            res.text.should.contain('agency registration page');
 
-                agent
-                  .post('/users/agency')
-                  .redirects(1)
-                  .send(agencyRequest)
-                  .end((err, res) => {
+            User.findOne({ email: signupRequest.email }).then((user) => {
+              let agencyRequest = {
+                agencyName: 'testAgencyName',
+                agencyWebsite: 'http://testAgencyWebsite',
+                agencyPhone: '12334556',
+                agencyBio: 'testAgencyBio',
+              };
+
+              agent
+                .post('/users/agency')
+                .send(agencyRequest)
+                .end((err, res) => {
+                  res.body.should.have.property('url');
+
+                  agent.get('/users/profile').end((err, res) => {
+                    res.text.should.contain('Welcome ' + user.fName);
+                    res.text.should.contain('Your email is unverified');
+
                     Agency.findOne({ accountManager: user._id }).then(
                       (agency) => {
+                        agency.agencyName.should.equal(
+                          agencyRequest.agencyName
+                        );
                         const aUserId = agency.accountManager.toString();
                         const userId = user._id.toString();
                         aUserId.should.equal(userId);
@@ -485,7 +465,8 @@ describe('Users', () => {
                       }
                     );
                   });
-              });
+                });
+            });
           });
         });
     });

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -31,7 +31,7 @@
 
             <% if (!user.emailVerified) { %>
             <p class="mt-5 text-danger notify"><i class="fa fa-exclamation-triangle" aria-hidden="true">
-                </i>Your email is unverified. Please verify your email address.
+                </i>Your email is unverified. Some features are disabled until email is verified.
             </p>
             <% } %>
 

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -28,6 +28,13 @@
     <header class="profile-header comf-font">
         <div class="container justify-content-center">
 
+
+            <% if (!user.emailVerified) { %>
+            <p class="mt-5 text-danger notify"><i class="fa fa-exclamation-triangle" aria-hidden="true">
+                </i>Your email is unverified. Please verify your email address.
+            </p>
+            <% } %>
+
             <% if (user.userRole == 'partner' && locals.agency && (!agency.isVerified)) { %>
             <p class="mt-5 text-danger notify"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i>Wish card
                 creation feature is disabled for your account. <br> It will be enabled
@@ -151,8 +158,8 @@
                 <div class="row mb-5">
                     <h6 class="col form-notification">
 
-                        For this method, you need to watch <a href="https://youtu.be/P4P6jEqTXs4"
-                        target="_blank" class="highlight text-success">this video</a> and create an Amazon list first. <br>
+                        For this method, you need to watch <a href="https://youtu.be/P4P6jEqTXs4" target="_blank"
+                            class="highlight text-success">this video</a> and create an Amazon list first. <br>
 
                         We are developing new features to make the card creation much
                         easier in the future.<br>

--- a/views/wishCards.ejs
+++ b/views/wishCards.ejs
@@ -88,11 +88,14 @@
 								<div class="quick-font row button-center mt-2">
 									<button type="button" class="col wishcard-btn btn-navy-border"><a
 											href="/wishcards/<%= wishcards[i]._id %>">Read more</a></button>
-									<button type="button" data-toggle="modal"
+									<% if (!user.emailVerified) { %>
+										<button type="button" data-toggle="modal"
 										data-value-url="<%= wishcards[i].wishItemURL %>"
 										data-value-name="<%= wishcards[i].childFirstName %>"
+										
 										data-target="#wishCardDonateModal" class="col wishcard-btn btn-navy-bg">Donate
 										Gift</button>
+									<% } %>
 								</div>
 							</div>
 


### PR DESCRIPTION
- Moved email verification to its own function (outside /post/ signup route, so we can reuse it)
	- To do: Add a resend email verification link to unverified profiles
- POST signup
	- Modified return object
	- Removed email (frontend doesn't display the toast for it anymore)
	- Added url (used to redirect to next page - depending on user role)
- Removed check for email verification
	- User can login without verifying their email
- Modified verification messages (since user can login right away, no need to say you can login now :))
- Modified tests